### PR TITLE
fix(HashMap): fix array insertion helper function

### DIFF
--- a/src/common/array-operations.ts
+++ b/src/common/array-operations.ts
@@ -42,7 +42,7 @@ export function remove<T>(index: number, array: Array<T>): Array<T> {
  */
 export function insert<T>(index: number, value: T, array: Array<T>): Array<T> {
   const length = array.length;
-  const newArray = Array(length - 1);
+  const newArray = Array(length + 1);
 
   let i = 0;
 
@@ -51,7 +51,7 @@ export function insert<T>(index: number, value: T, array: Array<T>): Array<T> {
 
   newArray[i++] = value;
 
-  for (; i < length; ++i)
+  for (; i < length + 1; ++i)
     newArray[i] = array[i - 1];
 
   return newArray;


### PR DESCRIPTION
- [ ] I added new tests for the issue I fixed or the feature I built
- [ ] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`

Your package is missing tests, so short of starting the unit testing chore myself; I just applied the same fix from my conversion of your code, which I've just seen fixing the issue in my own tests. If you want to write a test, add more than two items to a map. The first entry creates an `IndexedNode` and the second entry is inserted into a copy of the first `IndexedNode` successfully because the logic sort of works when there is only a single existing array element. The third entry fails to insert because the insertion code creates the wrong sized target array, and then fails to iterate to the end of that array. I suspect the code was copy/pasted from `remove<T>()` and not updated correctly.